### PR TITLE
Add caching to user.controller

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -101,6 +101,7 @@ export class UserController {
 
     return this.getCachedResponse(`users:ids:${ids.join(',')}`, () => this.usersService.findByIds(ids, user));
   }
+
   /**
    * Handles the 'users.update' message pattern to update a user.
    *

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -7,6 +7,7 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateUserDto, UpdateUserDto } from './dto';
 import { CurrentUser, Role, UserResponse, UserSummary } from './interfaces';
 import { UserService } from './user.service';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
 const mockPrisma = {
   user: { create: jest.fn(), findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn(), update: jest.fn() },
@@ -45,7 +46,11 @@ describe('UserService', () => {
 
   beforeEach(async () => {
     const moduleRef: TestingModule = await Test.createTestingModule({
-      providers: [UserService, { provide: PrismaService, useValue: mockPrisma }],
+      providers: [
+        UserService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: CACHE_MANAGER, useValue: { reset: jest.fn() } },
+      ],
     }).compile();
 
     userService = moduleRef.get<UserService>(UserService);
@@ -94,7 +99,7 @@ describe('UserService', () => {
       const error = new Error('User creation failed');
       mockPrisma.user.create.mockRejectedValue(error);
 
-      await expect(userService.create(createUserDto)).rejects.toThrow('User creation failed');
+      await expect(userService.create(createUserDto)).rejects.toThrow('[ERROR] Ocurrió un error al crear el usuario');
       expect(mockPrisma.user.create).toHaveBeenCalledWith({
         data: { ...createUserDto, password: expect.any(String) },
         include: USER_INCLUDE,


### PR DESCRIPTION
This pull request introduces caching mechanisms to the `UserController` and updates the corresponding unit tests to handle caching logic. The most important changes include adding a cache manager to the `UserController`, updating the tests to mock the cache manager, and adding new test cases to verify caching behavior.

### Caching Mechanism Integration:

* [`src/user/user.controller.spec.ts`](diffhunk://#diff-503e879b497e909b8d5a8e8f94195813bc8cfc5319b3f1305d76f147f19de48dR1): Added `CACHE_MANAGER` and mock cache manager to the test setup. Updated `UserController` instantiation to include the cache manager. Added test cases to verify caching behavior for methods `findOne`, `findOneByUsername`, and `findByIds`. [[1]](diffhunk://#diff-503e879b497e909b8d5a8e8f94195813bc8cfc5319b3f1305d76f147f19de48dR1) [[2]](diffhunk://#diff-503e879b497e909b8d5a8e8f94195813bc8cfc5319b3f1305d76f147f19de48dR33-R61) [[3]](diffhunk://#diff-503e879b497e909b8d5a8e8f94195813bc8cfc5319b3f1305d76f147f19de48dL115-R204) [[4]](diffhunk://#diff-503e879b497e909b8d5a8e8f94195813bc8cfc5319b3f1305d76f147f19de48dR241-R284)
* [`src/user/user.controller.ts`](diffhunk://#diff-8d9225643f0fb2cba6a02345b85424c6ce325e67c6512326c659b83e85ff57e5R104): Integrated cache manager into the `UserController` to cache responses for user retrieval methods.

### Unit Test Updates:

* [`src/user/user.service.spec.ts`](diffhunk://#diff-a7ea0b26e3eee2ca6b8bb3551d967029e45f7599e9d6a21a5845ef726bd43fd4R10): Added `CACHE_MANAGER` to the test setup. Updated error message in the `create` method test to match the new error format. [[1]](diffhunk://#diff-a7ea0b26e3eee2ca6b8bb3551d967029e45f7599e9d6a21a5845ef726bd43fd4R10) [[2]](diffhunk://#diff-a7ea0b26e3eee2ca6b8bb3551d967029e45f7599e9d6a21a5845ef726bd43fd4L48-R53) [[3]](diffhunk://#diff-a7ea0b26e3eee2ca6b8bb3551d967029e45f7599e9d6a21a5845ef726bd43fd4L97-R102)…val methods